### PR TITLE
feat(beam): Add method to set partial beam directions

### DIFF
--- a/src/beam.ts
+++ b/src/beam.ts
@@ -41,6 +41,8 @@ const BEAM_LEFT = 'L';
 const BEAM_RIGHT = 'R';
 const BEAM_BOTH = 'B';
 
+export type PartialBeamDirection = typeof BEAM_LEFT | typeof BEAM_RIGHT | typeof BEAM_BOTH;
+
 /** `Beams` span over a set of `StemmableNotes`. */
 export class Beam extends Element {
   static get CATEGORY(): string {
@@ -73,6 +75,15 @@ export class Beam extends Element {
   private break_on_indices: number[];
   private beam_count: number;
   private unbeamable?: boolean;
+
+  /**
+   * Overrides to default beam directions for secondary-level beams that do not
+   * connect to any other note. See further explanation at
+   * `setPartialBeamSideAt`
+   */
+  private forced_partial_directions: {
+    [noteIndex: number]: PartialBeamDirection;
+  } = {};
 
   /** Get the direction of the beam */
   getStemDirection(): number {
@@ -527,6 +538,33 @@ export class Beam extends Element {
     return this;
   }
 
+  /**
+   * Forces the direction of a partial beam (a secondary-level beam that exists
+   * on one note only of the beam group). This is useful in rhythms such as 6/8
+   * eighth-sixteenth-eighth-sixteenth, where the direction of the beam on the
+   * first sixteenth note can help imply whether the rhythm is to be felt as
+   * three groups of eighth notes (typical) or as two groups of three-sixteenths
+   * (less common):
+   * ```
+   *  ┌───┬──┬──┐      ┌──┬──┬──┐
+   *  │   ├─ │ ─┤  vs  │ ─┤  │ ─┤
+   *  │   │  │  │      │  │  │  │
+   * ```
+   */
+  setPartialBeamSideAt(noteIndex: number, side: PartialBeamDirection) {
+    this.forced_partial_directions[noteIndex] = side;
+    return this;
+  }
+
+  /**
+   * Restore the default direction of a partial beam (a secondary-level beam
+   * that does not connect to any other notes).
+   */
+  unsetPartialBeamSideAt(noteIndex: number) {
+    delete this.forced_partial_directions[noteIndex];
+    return this;
+  }
+
   /** Return the y coordinate for linear function. */
   getSlopeY(x: number, first_x_px: number, first_y_px: number, slope: number): number {
     return first_y_px + (x - first_x_px) * slope;
@@ -712,10 +750,19 @@ export class Beam extends Element {
   }
 
   /** Return upper level beam direction. */
-  lookupBeamDirection(duration: string, prev_tick: number, tick: number, next_tick: number): string {
+  lookupBeamDirection(
+    duration: string,
+    prev_tick: number,
+    tick: number,
+    next_tick: number,
+    noteIndex: number
+  ): PartialBeamDirection {
     if (duration === '4') {
       return BEAM_LEFT;
     }
+
+    const forcedBeamDirection = this.forced_partial_directions[noteIndex];
+    if (forcedBeamDirection) return forcedBeamDirection;
 
     const lookup_duration = `${Tables.durationToNumber(duration) / 2}`;
     const prev_note_gets_beam = prev_tick < Tables.durationToTicks(lookup_duration);
@@ -730,7 +777,7 @@ export class Beam extends Element {
       return BEAM_RIGHT;
     }
 
-    return this.lookupBeamDirection(lookup_duration, prev_tick, tick, next_tick);
+    return this.lookupBeamDirection(lookup_duration, prev_tick, tick, next_tick, noteIndex);
   }
 
   /** Get the x coordinates for the beam lines of specific `duration`. */
@@ -803,7 +850,7 @@ export class Beam extends Element {
             const prev_tick = prev_note.getIntrinsicTicks();
             const next_tick = next_note.getIntrinsicTicks();
             const tick = note.getIntrinsicTicks();
-            const beam_direction = this.lookupBeamDirection(duration, prev_tick, tick, next_tick);
+            const beam_direction = this.lookupBeamDirection(duration, prev_tick, tick, next_tick, i);
 
             if ([BEAM_LEFT, BEAM_BOTH].includes(beam_direction)) {
               current_beam.end = current_beam.start - partial_beam_length;

--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -1,6 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
+import { PartialBeamDirection } from '.';
 import { Accidental } from './accidental';
 import { Articulation } from './articulation';
 import { Dot } from './dot';
@@ -501,7 +502,16 @@ export class EasyScore {
     return result;
   }
 
-  beam(notes: StemmableNote[], options?: { autoStem?: boolean; secondaryBeamBreaks?: number[] }): StemmableNote[] {
+  beam(
+    notes: StemmableNote[],
+    options?: {
+      autoStem?: boolean;
+      secondaryBeamBreaks?: number[];
+      partialBeamDirections?: {
+        [noteIndex: number]: PartialBeamDirection;
+      };
+    }
+  ): StemmableNote[] {
     this.factory.Beam({ notes, options });
     return notes;
   }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -2,6 +2,7 @@
 // @author Mohit Cheppudira
 // MIT License
 
+import { PartialBeamDirection } from '.';
 import { Accidental } from './accidental';
 import { Annotation, AnnotationHorizontalJustify, AnnotationVerticalJustify } from './annotation';
 import { Articulation } from './articulation';
@@ -494,9 +495,23 @@ export class Factory {
     return tuplet;
   }
 
-  Beam(params: { notes: StemmableNote[]; options?: { autoStem?: boolean; secondaryBeamBreaks?: number[] } }): Beam {
+  Beam(params: {
+    notes: StemmableNote[];
+    options?: {
+      autoStem?: boolean;
+      secondaryBeamBreaks?: number[];
+      partialBeamDirections?: {
+        [noteIndex: number]: PartialBeamDirection;
+      };
+    };
+  }): Beam {
     const beam = new Beam(params.notes, params.options?.autoStem).setContext(this.context);
     beam.breakSecondaryAt(params.options?.secondaryBeamBreaks ?? []);
+    if (params.options?.partialBeamDirections) {
+      Object.entries(params.options?.partialBeamDirections).forEach(([noteIndex, direction]) => {
+        beam.setPartialBeamSideAt(Number(noteIndex), direction);
+      });
+    }
     this.renderQ.push(beam);
     return beam;
   }

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -39,6 +39,7 @@ const BeamTests = {
     run('Lengthy Beam', lenghty);
     run('Outlier Beam', outlier);
     run('Break Secondary Beams', breakSecondaryBeams);
+    run('Partial Beam Direction Test', partialBeamDirection);
     run('TabNote Beams Up', tabBeamsUp);
     run('TabNote Beams Down', tabBeamsDown);
     run('TabNote Auto Create Beams', autoTabBeams);
@@ -164,6 +165,36 @@ function breakSecondaryBeams(options: TestOptions): void {
   f.draw();
 
   ok(true, 'Breaking Secondary Beams Test');
+}
+
+function partialBeamDirection(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 200);
+  const stave = f.Stave({ y: 20 });
+  const score = f.EasyScore();
+
+  const voice = score.voice.bind(score);
+  const beam = score.beam.bind(score);
+  const notes = score.notes.bind(score);
+
+  const voices = [
+    voice(
+      [
+        // Default beaming:
+        beam(notes('f4/8, f4/16, f4/8, f4/16', { stem: 'up' })),
+        // Force first 16th beam right
+        beam(notes('f4/8, f4/16, f4/8, f4/16', { stem: 'up' }), { partialBeamDirections: { '1': 'R' } }),
+        // Force first 16th beam left
+        beam(notes('f4/8, f4/16, f4/8, f4/16', { stem: 'up' }), { partialBeamDirections: { '1': 'L' } }),
+      ].reduce(concat),
+      { time: '9/8' }
+    ),
+  ];
+
+  f.Formatter().joinVoices(voices).formatToStave(voices, stave);
+
+  f.draw();
+
+  ok(true, 'Partial beam direction test');
 }
 
 function slopey(options: TestOptions): void {


### PR DESCRIPTION
The direction of partial beams (beams at a 16th note level subdivision or smaller that do not connect to another beam) can convey important musical information to performers about how to group notes together. For instance, when in 6/8, the two versions below imply different rhythmic accentuation:

<img width="390" alt="image" src="https://user-images.githubusercontent.com/8905340/156828144-66079200-3395-4dbb-88a3-8de176bfd058.png">

This PR adds `beam.setPartialBeamDirectionAt(noteIndex, beamDirection)` and `beam.unsetPartialBeamDirectionAt(noteIndex)`, as well as a `partialBeamDirections` option on the `EasyScore.beam`.